### PR TITLE
Shift site messaging from "coming soon" to book promotion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# Surviving the Singularity
+
+## Project Overview
+
+**Surviving the Singularity** is a book + website by Christopher Tavolazzi about understanding, preparing for, and thriving through the most transformative period in human history — the technological singularity.
+
+The site serves as the book's home base: marketing, blog, book reader, and community hub.
+
+## Tech Stack
+
+- **Framework:** SvelteKit 2.0 + Vite 5
+- **Styling:** Tailwind CSS 3.4 + custom CSS (dark-first design)
+- **UI Library:** Flowbite Svelte
+- **Markdown:** mdsvex for `.md`/`.svx` files
+- **Backend:** Supabase (auth, storage)
+- **Payments:** Stripe
+- **Images:** Sharp + vite-imagetools (auto WebP)
+- **Deployment:** adapter-auto
+
+## Key Commands
+
+```bash
+npm run dev          # Start dev server
+npm run build        # Production build
+npm run preview      # Preview production build
+npm run optimize-images  # Optimize images
+npm run create-blog  # Scaffold a new blog post
+```
+
+## Project Structure
+
+```
+src/
+├── routes/              # SvelteKit pages
+│   ├── +page.svelte     # Homepage (hero, countdown, timeline, features, FAQ)
+│   ├── +layout.svelte   # Root layout (banner, navbar, footer)
+│   ├── blog/            # Blog listing + individual posts
+│   ├── book/[sectionId] # Book reader with pagination & progress
+│   ├── about/           # Mission / about page
+│   ├── sample/          # Book sample / preview
+│   ├── start-here/      # Onboarding page
+│   └── api/             # API endpoints
+├── lib/
+│   ├── components/      # 64+ Svelte components
+│   ├── data/
+│   │   ├── book-draft-v2/   # Full book content (19 markdown files, 12 chapters)
+│   │   ├── blog-posts/      # Blog posts (content.md + index.js each)
+│   │   ├── quotes.json      # Featured quotes
+│   │   ├── timelineItems.json
+│   │   └── technologies.json
+│   ├── stores/          # Svelte stores (darkMode, bookPage, etc.)
+│   ├── utils/           # Helpers (navigation, etc.)
+│   └── styles/          # Global styles
+static/
+├── images/              # Static assets, book cover, blog images
+work_efforts/            # Johnny Decimal project management system
+docs/contributing/       # CONTRIBUTING.md, STYLE_GUIDE.md
+```
+
+## Book Content
+
+The book has 12 chapters + intro, epilogue, glossary, and further reading:
+
+1. AI & the Singularity overview
+2. AI's impact on jobs and economy
+3. AI in everyday life
+4. AI in healthcare
+5. AI in education
+6. AI in art, creativity, entertainment
+7. AI in relationships
+8. AI in politics
+9. AI in finance
+10. Surviving the age of AI
+11. Thriving in the age of AI
+12. Looking forward
+
+**Writing voice:** Conversational, witty, direct address ("you"), pop culture references, satirical commentary balanced with genuine optimism. NOT doom-and-gloom — practical and empowering.
+
+## Design System
+
+- **Theme:** Dark-first (forced dark mode via `document.documentElement.classList.add('dark')`)
+- **Primary accent:** Blue gradient (#63b3ed / #3b82f6 / #8b5cf6)
+- **Background:** Deep navy (#020617 / #0f172a)
+- **Text:** Light slate (#e2e8f0 primary, #94a3b8 secondary)
+- **Fonts:** Inter (body), JetBrains Mono (code/accents), Orbitron (special headings)
+- **Feel:** Futuristic, clean, editorial — like a tech magazine from 2030
+
+## Current Status: Book Revival Phase
+
+The site was rebuilt with a fresh v2 design (new hero, navbar, footer, theme). We are now entering the **book revival phase** — shifting from "under construction" to actively promoting and hyping the book.
+
+### Revival Goals
+- Transform the site from "coming soon" energy to "the book is HERE" energy
+- Drive readers to explore the book content
+- Build excitement and shareability
+- Position the book as essential reading for the AI age
+- Encourage word-of-mouth sharing
+
+### Key Pages for Book Promotion
+- `/sample` — Book sample/preview (primary conversion page)
+- `/book/[sectionId]` — Full book reader
+- `/start-here` — Onboarding funnel
+- `/blog` — Supporting content that builds authority
+
+## Environment Variables
+
+```
+SUPABASE_URL, SUPABASE_SERVICE_KEY
+PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY
+STRIPE_SECRET_KEY, STRIPE_PRICE_ID
+PUBLIC_BASE_URL
+```
+
+## Blog System
+
+Blog posts live in `src/lib/data/blog-posts/<slug>/`:
+- `content.md` — Post body in markdown
+- `index.js` — Metadata (title, date, author, excerpt, featured image, slug)
+
+Use `npm run create-blog` to scaffold new posts.
+
+## Important Notes
+
+- The site uses Svelte 4 reactive syntax (`$:`, `export let`, etc.) — not Svelte 5 runes
+- Dark mode is force-enabled globally; no light mode toggle needed
+- Image optimization runs at build time; use `/images/` path for static assets
+- The construction banner in `+layout.svelte` should reflect current project phase
+- Book cover image: `/images/Surviving-the-Singularity-Cover.png` (+ `.webp` variant)

--- a/src/lib/components/BookCallout.svelte
+++ b/src/lib/components/BookCallout.svelte
@@ -4,12 +4,12 @@
   import SafeResponsiveImage from './SafeResponsiveImage.svelte';
 
   // Props
-  export let title = "Navigate the Path to Singularity";
+  export let title = "The Book That Prepares You for What's Next";
   export const imageSrc = bookCoverImage; // Use the imported image
   export const imageWebPSrc = bookCoverImageWebP; // WebP version
-  export let subtitle = "Want to know more?";
-  export let description = "Get the insights and strategies you need to prepare for the technological changes that will reshape our world.";
-  export let buttonText = "Explore the Book";
+  export let subtitle = "Read it. Share it. Survive it.";
+  export let description = "AI is rewriting the rules of work, creativity, relationships, and what it means to be human. This book gives you the map.";
+  export let buttonText = "Read the Free Sample";
   export let buttonLink = "/sample"; // Default to sample page
   export let shareLink = "https://survivingthesingularity.com"; // Default share link
   export let showShareButton = true; // Whether to show the share button
@@ -55,15 +55,15 @@
       <div class="grid grid-cols-1 gap-3 mb-6 max-w-2xl mx-auto text-left">
         <div class="flex items-center">
           <svg class="w-4 h-4 mr-2 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-          <span class="text-gray-300">Learn to navigate rapid technological changes</span>
+          <span class="text-gray-300">12 chapters covering AI's impact on every part of life</span>
         </div>
         <div class="flex items-center">
           <svg class="w-4 h-4 mr-2 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-          <span class="text-gray-300">Understand AI's impact on your career & future</span>
+          <span class="text-gray-300">Written for humans, not technologists — no jargon required</span>
         </div>
         <div class="flex items-center">
           <svg class="w-4 h-4 mr-2 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-          <span class="text-gray-300">Actionable strategies to thrive in the new era</span>
+          <span class="text-gray-300">Practical strategies you can use today, not someday</span>
         </div>
       </div>
     </div>

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -57,8 +57,9 @@
   $: currentPath = $page.url.pathname;
 
   const navLinks = [
-    { href: '/about', label: 'About' },
+    { href: '/sample', label: 'The Book' },
     { href: '/blog', label: 'Blog' },
+    { href: '/about', label: 'About' },
     { href: '/start-here', label: 'Start Here' },
   ];
 </script>
@@ -123,18 +124,6 @@
           </svg>
         </a>
       {/each}
-      <a
-        href="/sample"
-        class="mobile-link"
-        class:active={currentPath === '/sample'}
-        on:click={(e) => navigateTo('/sample', e)}
-        style="animation-delay: {navLinks.length * 50}ms"
-      >
-        <span class="mobile-link-text">Book Sample</span>
-        <svg class="mobile-link-arrow" width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path d="M6 4L10 8L6 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </a>
     </div>
   </div>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,12 +34,12 @@
 </script>
 
 <div class="app">
-  <!-- Under Construction Banner -->
+  <!-- Book Revival Banner -->
   <div class="construction-banner">
     <div class="banner-content">
       <span class="banner-pulse"></span>
       <span class="banner-text">
-        We're rebuilding for the future. New content, new look — more coming soon.
+        The book is back. <a href="/sample" class="banner-link">Read the free sample</a> and prepare for what's next.
       </span>
       <span class="banner-pulse"></span>
     </div>
@@ -120,6 +120,18 @@
     color: #94a3b8;
     letter-spacing: 0.03em;
     font-weight: 400;
+  }
+
+  .banner-text :global(.banner-link) {
+    color: #63b3ed;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    font-weight: 500;
+    transition: color 0.2s;
+  }
+
+  .banner-text :global(.banner-link:hover) {
+    color: #93c5fd;
   }
 
   .app {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,23 +62,23 @@
 
 		{#if heroVisible}
 			<div class="hero-content" in:fade={{ duration: 800 }}>
-				<p class="hero-eyebrow">Est. 2024 &mdash; Rethinking what comes next</p>
+				<p class="hero-eyebrow">The book on AI the world needs right now</p>
 				<h1 class="hero-title">
 					<span class="hero-title-line">Surviving</span>
 					<span class="hero-title-line hero-title-accent">the Singularity</span>
 				</h1>
 				<p class="hero-subtitle">
-					A guide to understanding, preparing for, and thriving through the most transformative period in human history.
+					The AI revolution isn't coming — it's here. This is your guide to understanding it, preparing for it, and thriving through it.
 				</p>
 				<div class="hero-actions">
-					<a href="/start-here" class="hero-btn hero-btn-primary">
-						Start Here
+					<a href="/sample" class="hero-btn hero-btn-primary">
+						Read the Free Sample
 						<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 							<path d="M3 8H13M13 8L9 4M13 8L9 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 						</svg>
 					</a>
-					<a href="/blog" class="hero-btn hero-btn-secondary">
-						Read the Blog
+					<a href="/start-here" class="hero-btn hero-btn-secondary">
+						Start Here
 					</a>
 				</div>
 			</div>
@@ -111,26 +111,26 @@
 	<!-- ═══════════════════════════════════════════════════ -->
 	<section class="whats-coming">
 		<div class="whats-coming-inner">
-			<h2 class="section-heading">What We're Building</h2>
-			<p class="section-subheading">This site is evolving. Here's what's on the horizon.</p>
+			<h2 class="section-heading">Why This Book Matters Now</h2>
+			<p class="section-subheading">AI is reshaping everything. Here's what you'll find inside.</p>
 			<div class="roadmap-grid">
 				<div class="roadmap-card">
 					<div class="roadmap-icon">01</div>
-					<h3>Deep Dives</h3>
-					<p>Long-form explorations of AI breakthroughs, from synthetic biology to neural interfaces.</p>
-					<span class="roadmap-status">In Progress</span>
+					<h3>Understand the Shift</h3>
+					<p>Cut through the hype and fear. Get a clear-eyed look at what AI actually means for your life, career, and future.</p>
+					<span class="roadmap-status">12 Chapters</span>
 				</div>
 				<div class="roadmap-card">
 					<div class="roadmap-icon">02</div>
-					<h3>The Workbook</h3>
-					<p>Practical frameworks and exercises for navigating technological disruption in your life and career.</p>
-					<span class="roadmap-status">Coming Soon</span>
+					<h3>Practical Strategies</h3>
+					<p>Not just theory — actionable frameworks for thriving when the world changes faster than you can refresh your feed.</p>
+					<span class="roadmap-status">Battle-Tested</span>
 				</div>
 				<div class="roadmap-card">
 					<div class="roadmap-icon">03</div>
-					<h3>Community</h3>
-					<p>A space for thinkers, builders, and the curious to connect and share survival strategies.</p>
-					<span class="roadmap-status">Planned</span>
+					<h3>Stay Human</h3>
+					<p>The singularity doesn't have to be scary. Learn how to keep what makes us human while embracing what makes us powerful.</p>
+					<span class="roadmap-status">Essential Reading</span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
Repositioned the entire site from a "under construction" phase to an active book promotion phase. Updated messaging, CTAs, and navigation to drive readers toward the book content and free sample.

## Key Changes

**Homepage & Hero Section**
- Changed hero eyebrow from "Est. 2024 — Rethinking what comes next" to "The book on AI the world needs right now"
- Updated hero subtitle to emphasize the book's immediacy: "The AI revolution isn't coming — it's here..."
- Swapped primary CTA from "Start Here" to "Read the Free Sample" (linking to `/sample`)
- Made "Start Here" the secondary CTA instead

**"What We're Building" Section**
- Renamed section to "Why This Book Matters Now"
- Reframed three cards from feature roadmap to book content highlights:
  - "Deep Dives" → "Understand the Shift" (12 chapters)
  - "The Workbook" → "Practical Strategies" (battle-tested)
  - "Community" → "Stay Human" (essential reading)
- Updated status badges to reflect book content rather than development status

**Navigation & Layout**
- Reordered navbar links: "The Book" now appears first, followed by Blog and About
- Removed redundant "Book Sample" mobile nav link (now consolidated under "The Book")
- Updated construction banner from "We're rebuilding..." to "The book is back" with direct link to `/sample`
- Added styling for banner link with hover states

**Book Callout Component**
- Updated title, subtitle, and description to emphasize the book's value proposition
- Changed button text from "Explore the Book" to "Read the Free Sample"
- Refreshed feature bullets to highlight book content (12 chapters, no jargon, practical strategies)

**Documentation**
- Added comprehensive `CLAUDE.md` with project overview, tech stack, structure, design system, and current status

## Implementation Details
- All changes maintain existing component structure and styling
- Navigation reordering uses existing `navLinks` array without breaking responsive behavior
- Banner link styling uses Tailwind classes with custom color transitions
- No breaking changes to routes or data structures

https://claude.ai/code/session_01Bv4Mv2vSGKBRatZ6qffcq3